### PR TITLE
TCP performance improvement: If the argement to Client.send is a list,

### DIFF
--- a/bernhard/__init__.py
+++ b/bernhard/__init__.py
@@ -164,8 +164,10 @@ class Client(object):
                 self.disconnect()
         return Message()
 
-    def send(self, event):
-        message = Message(events=[Event(params=event)])
+    def send(self, events):
+        if not type(events) == list:
+            events = [events]
+        message = Message(events=[Event(params=event) for event in events])
         response = self.transmit(message)
         return response.ok
 


### PR DESCRIPTION
Hi Benjamin,

I noticed that TCP performance was pretty bad when I was trying to send
several hundred events at once.  My use cases is that I have an event data
source that has already been aggregated and I am breaking it up into events
to feed to riemann.

This version of Client.send takes a list or a single event as before. If
the event is a list, all the events are sent at once.  If the event is a single
Event, the method behaves as before the change.  For UDP, sending many
events in a single message will be a problem if max packet size is
exceeded.  The developer should already be aware of this.

Thanks for your good work,
Daniel Gardner