### PR TITLE
TLS related fixes

### DIFF
--- a/bernhard/__init__.py
+++ b/bernhard/__init__.py
@@ -30,6 +30,7 @@ class TCPTransport(object):
             try:
                 log.debug("Creating socket with %s %s %s", af, socktype, proto)
                 self.sock = socket.socket(af, socktype, proto)
+                self.sock.settimeout(15.0)
             except socket.error as e:
                 log.exception("Exception creating TCP socket: %s", e)
                 self.sock = None


### PR DESCRIPTION
Add debugging logs.
Add `__str__` method to `Event`.
Bytes passed into `socket.recv()` represent MAX bytes, therefore only read required bytes.
Don't set `socket.MSG_WAITALL` as its not compat with SSL wrapper