### PR TITLE
Changed metrics to use double for protobuff message

### DIFF
--- a/bernhard/__init__.py
+++ b/bernhard/__init__.py
@@ -138,13 +138,13 @@ class Event(object):
 
     def __getattr__(self, name):
         if name == 'metric':
-            name = 'metric_f'
+            name = 'metric_d'
         if name in set(f.name for f in pb.Event.DESCRIPTOR.fields):
             return getattr(self.event, name)
 
     def __setattr__(self, name, value):
         if name == 'metric':
-            name = 'metric_f'
+            name = 'metric_d'
         if name == 'tags':
             self.event.tags.extend(value)
         elif name == 'attributes':


### PR DESCRIPTION
Hello Benjamin,

I thought treating the metric as a double in the protobuff message would be better because then we would not be susceptible to large metrics losing precision when sent to Riemann. For example, this is an example from my Clojure REPL:

user=> (double 6928568577)
6.928568577E9
user=> (float 6928568577)
6.9285688E9

And it bit me because while doing my calculations, the original number was converted to a float in Clojure and lost precision, which resulted in me running into many problems while trying to write a unit test. I think float is only good up to 7 decimals (https://en.wikipedia.org/wiki/Single-precision_floating-point_format) so while it takes up more space, it's better to use double. 

I am by no means proficient in Clojure or Riemann or ProtocolBuffers, but I thought I'll let you know about this. Thanks!

