### PR TITLE
Fix python 2 / 3 version check for basestring

### DIFF
--- a/bernhard/__init__.py
+++ b/bernhard/__init__.py
@@ -11,7 +11,7 @@ import sys
 from . import pb
 
 string_type = str
-if sys.version_info[1] < 3:
+if sys.version_info.major < 3:
     string_type = basestring
 
 class TransportError(Exception):


### PR DESCRIPTION
sys.version_info[1] checks the minor version, so on python 2.7 string_type is set to `str` instead of `basestring`. This causes unicode strings to fail when bernhard attempts to convert them to str via string_type at line 158.